### PR TITLE
Biome Priority

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@ plugins {
 	id 'maven-publish'
 }
 
+loom {
+	accessWidenerPath = file("src/main/resources/atlas.accesswidener")
+}
+
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 

--- a/src/main/java/com/miir/atlas/mixin/RegistryElementCodecAccessor.java
+++ b/src/main/java/com/miir/atlas/mixin/RegistryElementCodecAccessor.java
@@ -1,0 +1,18 @@
+package com.miir.atlas.mixin;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.entry.RegistryElementCodec;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(RegistryElementCodec.class)
+public interface RegistryElementCodecAccessor<E> {
+
+    @Accessor
+    RegistryKey<? extends Registry<E>> getRegistryRef();
+
+    @Accessor
+    Codec<E> getElementCodec();
+}

--- a/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntry.java
+++ b/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntry.java
@@ -1,5 +1,6 @@
 package com.miir.atlas.world.gen.biome;
 
+import com.miir.atlas.Atlas;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.registry.entry.RegistryEntry;
@@ -10,15 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class BiomeEntry {
-    /*public static final Biome EMPTY = new Biome.Builder()
-            .precipitation(Biome.Precipitation.NONE)
-            .temperature(0.5f)
-            .downfall(0.5f)
-            .effects(new BiomeEffects.Builder()
-                    .build())
-            .build();*/
-
-    public static final Identifier EMPTY = new Identifier("the_void");
+    public static final Identifier EMPTY = Atlas.id("empty");
     public static final BiomeEntryPriorityCodec PRIORITY_CODEC = new BiomeEntryPriorityCodec();
 
     private final Optional<RegistryEntry<Biome>> biome;

--- a/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntry.java
+++ b/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntry.java
@@ -5,7 +5,6 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.BiomeEffects;
 
 import java.util.List;
 import java.util.Optional;
@@ -49,7 +48,6 @@ public class BiomeEntry {
             throw new IllegalStateException("biome entry for color " + color + " must specify either 'biome' key or 'priority' list");
         }
         for (RegistryEntry<Biome> priorityEntry : priority.get()) {
-            System.out.println(priorityEntry);
             if (!priorityEntry.matchesId(EMPTY)) {
                 return priorityEntry;
             }

--- a/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntry.java
+++ b/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntry.java
@@ -1,0 +1,71 @@
+package com.miir.atlas.world.gen.biome;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.BiomeEffects;
+
+import java.util.List;
+import java.util.Optional;
+
+public class BiomeEntry {
+    /*public static final Biome EMPTY = new Biome.Builder()
+            .precipitation(Biome.Precipitation.NONE)
+            .temperature(0.5f)
+            .downfall(0.5f)
+            .effects(new BiomeEffects.Builder()
+                    .build())
+            .build();*/
+
+    public static final Identifier EMPTY = new Identifier("the_void");
+    public static final BiomeEntryPriorityCodec PRIORITY_CODEC = new BiomeEntryPriorityCodec();
+
+    private final Optional<RegistryEntry<Biome>> biome;
+    private final Optional<List<RegistryEntry<Biome>>> priority;
+    private final int color;
+
+    private final RegistryEntry<Biome> topBiome;
+
+    public BiomeEntry(Optional<RegistryEntry<Biome>> biome, Optional<List<RegistryEntry<Biome>>> priority, int color) {
+        this.biome = biome;
+        this.priority = priority;
+        this.color = color;
+        topBiome = getTopBiome();
+    }
+
+    public static final Codec<BiomeEntry> CODEC = RecordCodecBuilder.create((instance) -> instance.group(
+            Biome.REGISTRY_CODEC.optionalFieldOf("biome").forGetter(BiomeEntry::getBiome),
+            PRIORITY_CODEC.listOf().optionalFieldOf("priority").forGetter(BiomeEntry::getPriority),
+            Codec.INT.fieldOf("color").forGetter(BiomeEntry::getColor)
+    ).apply(instance, BiomeEntry::new));
+
+    public RegistryEntry<Biome> getTopBiome() {
+        if (biome.isPresent()) {
+            return biome.get();
+        }
+        if (priority.isEmpty()) {
+            throw new IllegalStateException("biome entry for color " + color + " must specify either 'biome' key or 'priority' list");
+        }
+        for (RegistryEntry<Biome> priorityEntry : priority.get()) {
+            System.out.println(priorityEntry);
+            if (!priorityEntry.matchesId(EMPTY)) {
+                return priorityEntry;
+            }
+        }
+        throw new IllegalStateException("invalid final-priority biome for color " + color);
+    }
+
+    public Optional<RegistryEntry<Biome>> getBiome() {
+        return biome;
+    }
+
+    public Optional<List<RegistryEntry<Biome>>> getPriority() {
+        return priority.map(entries -> List.of(topBiome));
+    }
+
+    public int getColor() {
+        return color;
+    }
+}

--- a/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntry.java
+++ b/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntry.java
@@ -3,6 +3,7 @@ package com.miir.atlas.world.gen.biome;
 import com.miir.atlas.Atlas;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.registry.Registries;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.biome.Biome;

--- a/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntryPriorityCodec.java
+++ b/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntryPriorityCodec.java
@@ -1,6 +1,5 @@
 package com.miir.atlas.world.gen.biome;
 
-import com.miir.atlas.Atlas;
 import com.miir.atlas.mixin.RegistryElementCodecAccessor;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.DataResult;

--- a/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntryPriorityCodec.java
+++ b/src/main/java/com/miir/atlas/world/gen/biome/BiomeEntryPriorityCodec.java
@@ -1,0 +1,47 @@
+package com.miir.atlas.world.gen.biome;
+
+import com.miir.atlas.Atlas;
+import com.miir.atlas.mixin.RegistryElementCodecAccessor;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import net.minecraft.registry.RegistryEntryLookup;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.RegistryOps;
+import net.minecraft.registry.entry.RegistryElementCodec;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.biome.Biome;
+
+import java.util.Optional;
+
+public class BiomeEntryPriorityCodec extends RegistryElementCodec<Biome> {
+
+    public BiomeEntryPriorityCodec() {
+        super(RegistryKeys.BIOME, Biome.CODEC, false);
+    }
+
+    public RegistryEntry.Reference<Biome> getEmpty(RegistryElementCodecAccessor<Biome> accessor, RegistryEntryLookup<Biome> registryEntryLookup) {
+        RegistryKey<Biome> registryKey = RegistryKey.of(accessor.getRegistryRef(), BiomeEntry.EMPTY);
+        return registryEntryLookup.getOptional(registryKey).get();
+    }
+
+    @Override
+    public <T> DataResult<Pair<RegistryEntry<Biome>, T>> decode(DynamicOps<T> ops, T input) {
+        RegistryElementCodecAccessor<Biome> accessor = (RegistryElementCodecAccessor<Biome>) this;
+        if (ops instanceof RegistryOps registryOps) {
+            Optional<RegistryEntryLookup<Biome>> optional = registryOps.getEntryLookup(accessor.getRegistryRef());
+            if (optional.isEmpty()) {
+                return DataResult.error("Registry does not exist: " + accessor.getRegistryRef());
+            }
+            RegistryEntryLookup<Biome> registryEntryLookup = optional.get();
+            DataResult<Pair<Identifier, T>> dataResult = Identifier.CODEC.decode(ops, input);
+            Pair<Identifier, T> pair2 = dataResult.getOrThrow(false, s -> { throw new IllegalStateException(s); });
+            RegistryKey<Biome> registryKey = RegistryKey.of(accessor.getRegistryRef(), pair2.getFirst());
+            Optional<RegistryEntry.Reference<Biome>> result = registryEntryLookup.getOptional(registryKey);
+            return DataResult.success(result.orElse(getEmpty(accessor, registryEntryLookup))).map(reference -> Pair.of(reference, pair2.getSecond()));
+        }
+        return accessor.getElementCodec().decode(ops, input).map(pair -> pair.mapFirst(RegistryEntry::of));
+    }
+}

--- a/src/main/java/com/miir/atlas/world/gen/biome/source/AtlasBiomeSource.java
+++ b/src/main/java/com/miir/atlas/world/gen/biome/source/AtlasBiomeSource.java
@@ -15,6 +15,7 @@ import net.minecraft.world.biome.source.util.MultiNoiseUtil;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public class AtlasBiomeSource extends BiomeSource {
     private final NamespacedMapImage image;
@@ -23,11 +24,11 @@ public class AtlasBiomeSource extends BiomeSource {
     private final Int2ObjectArrayMap<RegistryEntry<Biome>> biomes = new Int2ObjectArrayMap<>();
     private final float horizontalScale;
 
-    protected AtlasBiomeSource(String path, List<BiomeEntry> biomes, RegistryEntry<Biome> defaultBiome, float horizontalScale) {
+    protected AtlasBiomeSource(String path, List<BiomeEntry> biomes, Optional<RegistryEntry<Biome>> defaultBiome, float horizontalScale) {
         super(biomes.stream().map(BiomeEntry::getTopBiome).toList());
         this.image = new NamespacedMapImage(path, NamespacedMapImage.Type.COLOR);
         this.biomeEntries = biomes;
-        this.defaultBiome = defaultBiome == null ? this.biomeEntries.get(0).getTopBiome() : defaultBiome;
+        this.defaultBiome = defaultBiome.orElse(this.biomeEntries.get(0).getTopBiome());
         this.horizontalScale = horizontalScale;
         for (BiomeEntry entry : this.biomeEntries) {
             this.biomes.put(entry.getColor(), entry.getTopBiome());
@@ -37,14 +38,14 @@ public class AtlasBiomeSource extends BiomeSource {
     public static final Codec<AtlasBiomeSource> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.fieldOf("biome_map").forGetter(AtlasBiomeSource::getPath),
             Codecs.nonEmptyList(BiomeEntry.CODEC.listOf()).fieldOf("biomes").forGetter(AtlasBiomeSource::getBiomeEntries),
-            Biome.REGISTRY_CODEC.optionalFieldOf("default", null).forGetter(AtlasBiomeSource::getDefaultBiome),
+            Biome.REGISTRY_CODEC.optionalFieldOf("default").forGetter(AtlasBiomeSource::getDefaultBiome),
             Codec.FLOAT.fieldOf("horizontal_scale").forGetter(AtlasBiomeSource::getHorizontalScale)
     ).apply(instance, AtlasBiomeSource::new));
 
     public List<BiomeEntry> getBiomeEntries() {
         return this.biomeEntries;
     }
-    public RegistryEntry<Biome> getDefaultBiome(){return this.defaultBiome;}
+    public Optional<RegistryEntry<Biome>> getDefaultBiome(){return Optional.of(this.defaultBiome);}
     public String getPath() {
         return this.image.getPath();
     }

--- a/src/main/java/com/miir/atlas/world/gen/biome/source/AtlasBiomeSource.java
+++ b/src/main/java/com/miir/atlas/world/gen/biome/source/AtlasBiomeSource.java
@@ -27,7 +27,7 @@ public class AtlasBiomeSource extends BiomeSource {
         super(biomes.stream().map(BiomeEntry::getTopBiome).toList());
         this.image = new NamespacedMapImage(path, NamespacedMapImage.Type.COLOR);
         this.biomeEntries = biomes;
-        this.defaultBiome = defaultBiome;
+        this.defaultBiome = defaultBiome == null ? this.biomeEntries.get(0).getTopBiome() : defaultBiome;
         this.horizontalScale = horizontalScale;
         for (BiomeEntry entry : this.biomeEntries) {
             this.biomes.put(entry.getColor(), entry.getTopBiome());
@@ -37,7 +37,7 @@ public class AtlasBiomeSource extends BiomeSource {
     public static final Codec<AtlasBiomeSource> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.fieldOf("biome_map").forGetter(AtlasBiomeSource::getPath),
             Codecs.nonEmptyList(BiomeEntry.CODEC.listOf()).fieldOf("biomes").forGetter(AtlasBiomeSource::getBiomeEntries),
-            Biome.REGISTRY_CODEC.fieldOf("default").forGetter(AtlasBiomeSource::getDefaultBiome),
+            Biome.REGISTRY_CODEC.optionalFieldOf("default", null).forGetter(AtlasBiomeSource::getDefaultBiome),
             Codec.FLOAT.fieldOf("horizontal_scale").forGetter(AtlasBiomeSource::getHorizontalScale)
     ).apply(instance, AtlasBiomeSource::new));
 

--- a/src/main/java/com/miir/atlas/world/gen/biome/source/AtlasBiomeSource.java
+++ b/src/main/java/com/miir/atlas/world/gen/biome/source/AtlasBiomeSource.java
@@ -2,6 +2,7 @@ package com.miir.atlas.world.gen.biome.source;
 
 import com.miir.atlas.Atlas;
 import com.miir.atlas.world.gen.NamespacedMapImage;
+import com.miir.atlas.world.gen.biome.BiomeEntry;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
@@ -23,12 +24,14 @@ public class AtlasBiomeSource extends BiomeSource {
     private final float horizontalScale;
 
     protected AtlasBiomeSource(String path, List<BiomeEntry> biomes, RegistryEntry<Biome> defaultBiome, float horizontalScale) {
-        super(biomes.stream().map(biomeEntry -> biomeEntry.biome).toList());
+        super(biomes.stream().map(BiomeEntry::getTopBiome).toList());
         this.image = new NamespacedMapImage(path, NamespacedMapImage.Type.BIOMES);
         this.biomeEntries = biomes;
         this.defaultBiome = defaultBiome;
         this.horizontalScale = horizontalScale;
-        for (BiomeEntry entry : this.biomeEntries) this.biomes.put(entry.color, entry.biome);
+        for (BiomeEntry entry : this.biomeEntries) {
+            this.biomes.put(entry.getColor(), entry.getTopBiome());
+        }
     }
 
     public static final Codec<AtlasBiomeSource> CODEC = RecordCodecBuilder.create(instance -> instance.group(
@@ -68,12 +71,5 @@ public class AtlasBiomeSource extends BiomeSource {
         if (x < 0 || z < 0 || x >= this.image.getWidth() || z >= this.image.getHeight()) return this.defaultBiome;
         this.image.loadPixelsInRange(x, z, false, Atlas.GEN_RADIUS);
         return this.biomes.getOrDefault(this.image.getPixels()[z][x], this.defaultBiome);
-    }
-
-    public record BiomeEntry(RegistryEntry<Biome> biome, int color) {
-        public static final Codec<BiomeEntry> CODEC = RecordCodecBuilder.create((instance) -> instance.group(
-                Biome.REGISTRY_CODEC.fieldOf("biome").forGetter(BiomeEntry::biome),
-                Codec.INT.fieldOf("color").forGetter(BiomeEntry::color)
-        ).apply(instance, BiomeEntry::new));
     }
 }

--- a/src/main/resources/atlas.accesswidener
+++ b/src/main/resources/atlas.accesswidener
@@ -1,0 +1,5 @@
+accessWidener v2 named
+
+extendable class net/minecraft/registry/entry/RegistryElementCodec
+
+accessible method net/minecraft/registry/entry/RegistryElementCodec <init> (Lnet/minecraft/registry/RegistryKey;Lcom/mojang/serialization/Codec;Z)V

--- a/src/main/resources/atlas.mixins.json
+++ b/src/main/resources/atlas.mixins.json
@@ -4,7 +4,8 @@
   "package": "com.miir.atlas.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "MinecraftServerMixin"
+    "MinecraftServerMixin",
+    "RegistryElementCodecAccessor"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/data/atlas/worldgen/biome/empty.json
+++ b/src/main/resources/data/atlas/worldgen/biome/empty.json
@@ -1,0 +1,42 @@
+{
+  "carvers": {},
+  "downfall": 0.5,
+  "effects": {
+    "fog_color": 12638463,
+    "mood_sound": {
+      "block_search_extent": 8,
+      "offset": 2,
+      "sound": "minecraft:ambient.cave",
+      "tick_delay": 6000
+    },
+    "sky_color": 8103167,
+    "water_color": 4159204,
+    "water_fog_color": 329011
+  },
+  "features": [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    []
+  ],
+  "precipitation": "none",
+  "spawn_costs": {},
+  "spawners": {
+    "ambient": [],
+    "axolotls": [],
+    "creature": [],
+    "misc": [],
+    "monster": [],
+    "underground_water_creature": [],
+    "water_ambient": [],
+    "water_creature": []
+  },
+  "temperature": 0.5
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,5 +35,6 @@
   },
   "suggests": {
     "another-mod": "*"
-  }
+  },
+  "accessWidener": "atlas.accesswidener"
 }


### PR DESCRIPTION
## Additions

- Biome "priority" list that can be used instead of the single `biome` key in a `BiomeEntry`
  - Goes through each entry in the list and finds the first one that exists

## Draft Topic

This system requires an "empty" biome that is defaulted to when there are invalid biomes in the list (instead of throwing an error). Should the empty biome be a custom biome for internal use, basically a copy of the void with the id of `atlas:empty`, or keeping it as `minecraft:the_void`, which players might want to use for other purposes?

Will write docs after features are finalized.